### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/fastcampus/projectboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/fastcampus/projectboard/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.projectboard.repository;
 
 import com.fastcampus.projectboard.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.projectboard.repository;
 
 import com.fastcampus.projectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,3 +22,7 @@ spring:
       hibernate.default_batch_fetch_size: 100
   h2.console.enabled: true
   sql.init.mode: always
+  data:
+    rest:
+      base-path: /api
+      detection-strategy: annotated

--- a/src/test/java/com/fastcampus/projectboard/controller/DataRestTest.java
+++ b/src/test/java/com/fastcampus/projectboard/controller/DataRestTest.java
@@ -1,0 +1,106 @@
+package com.fastcampus.projectboard.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import javax.transaction.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Data REST 테스트 - API 테스트")
+@Transactional // test에는 기본적으로 Rollback으로 적용
+@AutoConfigureMockMvc // 해당 어노테이션을 선언하지 않으면 MockMvc 사용 불가
+@SpringBootTest
+public class DataRestTest {
+
+    private final MockMvc mvc;
+
+
+    public DataRestTest(@Autowired  MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    void givenNothing_whenRequesting_thenReturnsArticlesJsonResonse(){
+        // Given
+
+        // When & Then
+        try {
+            mvc.perform(get("/api/articles"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    void givenNothing_whenRequestingArticle_thenReturnsArticlesJsonResonse(){
+        // Given
+
+        // When & Then
+        try {
+            mvc.perform(get("/api/articles/1"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticleCommentsFromArticle_thenReturnsArticlesJsonResonse(){
+        // Given
+
+        // When & Then
+        try {
+            mvc.perform(get("/api/articles/1/articleComments"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @DisplayName("[api] 댓글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticleComments_thenReturnsArticlesCommentsJsonResonse(){
+        // Given
+
+        // When & Then
+        try {
+            mvc.perform(get("/api/articleComments"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @DisplayName("[api] 댓글 단건 조회")
+    @Test
+    void givenNothing_whenRequestingArticleComment_thenReturnsArticleCommentJsonResonse(){
+        // Given
+
+        // When & Then
+        try {
+            mvc.perform(get("/api/articleComments/1"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST로 서비스하고, 해당 API 들의 존재 여부만 체크하게끔 통합테스트 작성